### PR TITLE
Fix generate_SBM_cluster.ipynb

### DIFF
--- a/data/SBMs/generate_SBM_CLUSTER.ipynb
+++ b/data/SBMs/generate_SBM_CLUSTER.ipynb
@@ -427,4 +427,3 @@
  "nbformat": 4,
  "nbformat_minor": 4
 }
-}


### PR DESCRIPTION
notebook was invalid due to typo